### PR TITLE
Do not hang forever if a rogue child ignores a SIGINT

### DIFF
--- a/tests/core/test_open_in_process.py
+++ b/tests/core/test_open_in_process.py
@@ -12,26 +12,16 @@ from trio_run_in_process.state import State
 
 @pytest.mark.trio
 async def test_open_in_proc_termination_while_running():
-    async def do_sleep_forever():
-        import trio
-
-        await trio.sleep_forever()
-
     with trio.fail_after(2):
-        async with open_in_process(do_sleep_forever) as proc:
+        async with open_in_process(trio.sleep_forever) as proc:
             proc.terminate()
     assert proc.returncode == 15
 
 
 @pytest.mark.trio
 async def test_open_in_proc_kill_while_running():
-    async def do_sleep_forever():
-        import trio
-
-        await trio.sleep_forever()
-
     with trio.fail_after(2):
-        async with open_in_process(do_sleep_forever) as proc:
+        async with open_in_process(trio.sleep_forever) as proc:
             proc.kill()
     assert proc.returncode == -9
     assert isinstance(proc.error, ProcessKilled)
@@ -39,13 +29,8 @@ async def test_open_in_proc_kill_while_running():
 
 @pytest.mark.trio
 async def test_open_proc_interrupt_while_running():
-    async def monitor_for_interrupt():
-        import trio
-
-        await trio.sleep_forever()
-
     with trio.fail_after(2):
-        async with open_in_process(monitor_for_interrupt) as proc:
+        async with open_in_process(trio.sleep_forever) as proc:
             proc.send_signal(signal.SIGINT)
         assert proc.returncode == 2
 
@@ -77,16 +62,33 @@ async def test_open_proc_unpickleable_params(touch_path):
 
 @pytest.mark.trio
 async def test_open_proc_outer_KeyboardInterrupt():
+    with trio.fail_after(2):
+        with pytest.raises(KeyboardInterrupt):
+            async with open_in_process(trio.sleep_forever) as proc:
+                raise KeyboardInterrupt
+        assert proc.returncode == 2
+
+
+@pytest.mark.trio
+async def test_proc_ignores_KeyboardInterrupt(monkeypatch):
+    # If we get a KeyboardInterrupt and the child process does not terminate after being sent a
+    # SIGINT, we send a SIGKILL to avoid open_in_process() from hanging indefinitely.
     async def sleep_forever():
         import trio
 
-        await trio.sleep_forever()
+        while True:
+            try:
+                await trio.lowlevel.checkpoint()
+            except KeyboardInterrupt:
+                pass
 
-    with trio.fail_after(2):
+    monkeypatch.setattr(constants, "SIGINT_TIMEOUT_SECONDS", 0.2)
+    with trio.fail_after(constants.SIGINT_TIMEOUT_SECONDS + 1):
         with pytest.raises(KeyboardInterrupt):
             async with open_in_process(sleep_forever) as proc:
                 raise KeyboardInterrupt
-        assert proc.returncode == 2
+        assert proc.returncode == -9
+        assert isinstance(proc.error, ProcessKilled)
 
 
 @pytest.mark.trio
@@ -112,38 +114,26 @@ async def test_unpickleable_exc():
 
 @pytest.mark.trio
 async def test_timeout_waiting_for_pid(monkeypatch):
-    sleep = trio.sleep
-
     async def wait_pid(self):
-        await sleep(constants.STARTUP_TIMEOUT_SECONDS + 0.1)
+        await trio.sleep(constants.STARTUP_TIMEOUT_SECONDS + 0.1)
 
     monkeypatch.setattr(Process, "wait_pid", wait_pid)
     monkeypatch.setattr(constants, "STARTUP_TIMEOUT_SECONDS", 1)
 
-    async def do_sleep_forever():
-        while True:
-            await sleep(0.1)
-
     with pytest.raises(trio.TooSlowError):
-        async with open_in_process(do_sleep_forever):
+        async with open_in_process(trio.sleep_forever):
             pass
 
 
 @pytest.mark.trio
 async def test_timeout_waiting_for_executing_state(monkeypatch):
-    sleep = trio.sleep
-
     async def wait_for_state(self, state):
         if state is State.EXECUTING:
-            await sleep(constants.STARTUP_TIMEOUT_SECONDS + 0.1)
+            await trio.sleep(constants.STARTUP_TIMEOUT_SECONDS + 0.1)
 
     monkeypatch.setattr(Process, "wait_for_state", wait_for_state)
     monkeypatch.setattr(constants, "STARTUP_TIMEOUT_SECONDS", 1)
 
-    async def do_sleep_forever():
-        while True:
-            await sleep(0.1)
-
     with pytest.raises(trio.TooSlowError):
-        async with open_in_process(do_sleep_forever):
+        async with open_in_process(trio.sleep_forever):
             pass

--- a/trio_run_in_process/constants.py
+++ b/trio_run_in_process/constants.py
@@ -2,3 +2,9 @@
 # open_in_process(). Can be overwritten via the TRIO_RUN_IN_PROCESS_STARTUP_TIMEOUT
 # environment variable.
 STARTUP_TIMEOUT_SECONDS = 5
+
+# The number of seconds that are given to a child process to exit after the
+# parent process gets a KeyboardInterrupt/SIGINT-signal and sends a `SIGINT` to
+# the child process. Can be overwritten via the TRIO_RUN_IN_PROCESS_SIGINT_TIMEOUT environment
+# variable.
+SIGINT_TIMEOUT_SECONDS = 2

--- a/trio_run_in_process/process.py
+++ b/trio_run_in_process/process.py
@@ -34,7 +34,12 @@ class Process(ProcessAPI[TReturn]):
         self._state_changed = trio.Event()
 
     def __str__(self) -> str:
-        return f"Process[{self._async_fn},args={self._args}]"
+        func = self._async_fn.__name__
+        if self._has_pid.is_set():
+            pid = str(self.pid)
+        else:
+            pid = "<unset>"
+        return f"Process[{func},args={self._args},pid={pid}]"
 
     #
     # State


### PR DESCRIPTION
When we get a KeyboardInterrupt we send a SIGINT to the child, but
if the child ignores that we now send a SIGKILL to ensure we don't
hang forever